### PR TITLE
.gitignore: make absolute paths relative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,22 @@
 .sw?
 .*.sw?
 *.beam
-/.erlang.mk/
-/cover/
-/deps/
-/doc/
-/ebin/
-/logs/
-/plugins/
+.erlang.mk/
+cover/
+deps/
+doc/
+ebin/
+logs/
+plugins/
 
-/rabbitmq_test.d
+rabbitmq_test.d
 
 # Generated certificates.
-/certs/client/
-/certs/server/
-/certs/testca/
+certs/client/
+certs/server/
+certs/testca/
 
 # Downloaded sources.
-/qpid_testsuite/
+qpid_testsuite/
 
 ct.cover.spec


### PR DESCRIPTION
When this repo is a dependency of another one, and only the other one `.git`'s folder is used, the absolute paths git-ignoring apply to the parent project too; thus possibly ignoring files from the parent project.
And really, there's no need to make these paths absolute.

Note: relative paths in `.gitignore` apply as if this file was located at `/.gitignore`.
