### PR TITLE
392: Test cluster-wide resource alarm status with `cluster_status` output

### DIFF
--- a/test/src/clustering_management.erl
+++ b/test/src/clustering_management.erl
@@ -491,6 +491,19 @@ force_reset_node(Config) ->
     start_app(Rabbit),
     assert_clustered([Rabbit, Hare]).
 
+%% Given: a cluster of two.
+status_with_alarm_with() -> cluster_ab.
+status_with_alarm([Rabbit, Hare]) ->
+
+    %% When: we ask for cluster status.
+    S = rabbit_test_configs:rabbitmqctl(Rabbit, cluster_status),
+    R = rabbit_test_configs:rabbitmqctl(Hare,   cluster_status),
+
+    %% Then: alarms are nowhere to be seen.
+    0 = string:str(S, "alarms"),
+    0 = string:str(R, "alarms").
+
+
 %% ----------------------------------------------------------------------------
 %% Internal utils
 

--- a/test/src/clustering_management.erl
+++ b/test/src/clustering_management.erl
@@ -499,9 +499,9 @@ status_with_alarm([Rabbit, Hare]) ->
     S = rabbit_test_configs:rabbitmqctl(Rabbit, cluster_status),
     R = rabbit_test_configs:rabbitmqctl(Hare,   cluster_status),
 
-    %% Then: alarms are nowhere to be seen.
-    0 = string:str(S, "alarms"),
-    0 = string:str(R, "alarms").
+    %% Then: both nodes have printed alarm information.
+    true = string:str(S, "alarms") > 0,
+    true = string:str(R, "alarms") > 0.
 
 
 %% ----------------------------------------------------------------------------


### PR DESCRIPTION
The test for https://github.com/rabbitmq/rabbitmq-server/issues/392.
